### PR TITLE
Changed 1.19.3 Changelog to actually be for 1.19.3

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,30 +1,3 @@
-1.19.2-0.1.0.4
+1.19.3-0.1.0.4
 
--- Added enchantment generator
--- Added halitosis generator (burns dragons breath)
--- Added potion generator
--- Added JEI integration
-
-
-1.19.2-0.1.0.3
-
--- Added culinary generator (burns food)
--- Added ender generator
--- Fixed copper generator recipe
-
-
-1.19.2-0.1.0.2
-
--- Fixed mineable tag breaking
--- Added tooltips with generator info
-
-
-1.19.2-0.1.0.1
-
--- Fixed fuel duplicating when upgrading a generator
--- Added emerald generator
-
-
-1.19.2-0.1.0.0
-
--- Initial release
+-- Ported to 1.19.3


### PR DESCRIPTION
It showed the changelog for 1.19.2 instead of 1.19.3. For the 1.19.3 changelog you need to go to the 1.19.2 branch.